### PR TITLE
Fix "Should iterate crates" test

### DIFF
--- a/campaigns/standalone-quests/unordered-key-set/test/testsuite/testCrates1.js
+++ b/campaigns/standalone-quests/unordered-key-set/test/testsuite/testCrates1.js
@@ -45,7 +45,9 @@ function testCrates(input) {
       const expectedIds = input.crates
         .map(crate => ethers.BigNumber.from(crate.id));
 
-      const actualIds = await cratesContract.getCrateIds();
+      const actualIds = (await cratesContract.getCrateIds())
+        .map(id => ethers.BigNumber.from(id));
+      
       expect(actualIds).to.have.deep.members(expectedIds);
 
     });


### PR DESCRIPTION
The problem:
The "Should iterate crates" test is failing with the following error message:
```
AssertionError: expected [ BigNumber{ …(2) }, …(9) ] to have the same members as [ …(10) ]
      + expected - actual


      at Context.<anonymous> (test\testsuite\testCrates1.js:50:38)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at runNextTicks (internal/process/task_queues.js:64:3)
      at listOnTimeout (internal/timers.js:526:9)
      at processTimers (internal/timers.js:500:7)
```

The root cause:
The `actualIds` is in hexadecimal format:
![image](https://user-images.githubusercontent.com/50733605/222201950-4c40a0ee-8a34-4a1b-8e1f-fa1cfefce353.png)

The fix:
Convert all `actualIds` into Bignumbers:
![image](https://user-images.githubusercontent.com/50733605/222202476-2e0dd59b-c726-4326-8e21-df13a37e3e71.png)

