### PR TITLE
TestAmuletCreation : restricted 2 tests to 'view'

### DIFF
--- a/campaigns/proxy-contracts/basic-proxies/test/foundry/UpgradeableMechsuit.2.t.sol
+++ b/campaigns/proxy-contracts/basic-proxies/test/foundry/UpgradeableMechsuit.2.t.sol
@@ -20,7 +20,7 @@ contract PublicTest1 is Test {
         suit = new UpgradeableMechSuit(suitLogic);
     }
 
-    function test_EIP1967_compliance() external {
+    function test_EIP1967_compliance() external view {
         address impl = _loadAddress(address(suit), IMPL_SLOT);
         assertEq(impl, suitLogic, "Bad implementation slot");
 

--- a/campaigns/token-standards/building-erc-721/test/foundry/testsuites/TestAmuletCreation.sol
+++ b/campaigns/token-standards/building-erc-721/test/foundry/testsuites/TestAmuletCreation.sol
@@ -16,6 +16,7 @@ abstract contract TestAmuletCreation is Test {
     struct Input {
         string uri;
     }
+
     Input input;
 
     address creator;
@@ -39,7 +40,7 @@ abstract contract TestAmuletCreation is Test {
         amulet = IMintable(address(new Amulet()));
     }
 
-    function test_have_name_and_symbol() external {
+    function test_have_name_and_symbol() external view {
         assertEq(amulet.name(), "Amulet");
         assertEq(amulet.symbol(), "AMULET");
     }
@@ -83,7 +84,7 @@ abstract contract TestAmuletCreation is Test {
         amulet.tokenURI(12345);
     }
 
-    function test_supports_correct_interfaces() external {
+    function test_supports_correct_interfaces() external view {
         assertEq(amulet.supportsInterface(ERC165_ID), true);
         assertEq(amulet.supportsInterface(ERC721_ID), true);
         assertEq(amulet.supportsInterface(ERC721_METADATA_ID), true);


### PR DESCRIPTION
2 test functions emitted warnings when ran. This PR restrict these functions to view to avoid these warnings.

![image](https://github.com/user-attachments/assets/013f4635-d3e8-4bad-9649-3fca1ba00679)
